### PR TITLE
dz kubernetes-operators

### DIFF
--- a/kubernetes-operators/cluster-role-binding.yaml
+++ b/kubernetes-operators/cluster-role-binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: mysql-admin
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: mysql-admin
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: mysql-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes-operators/cluster-role.yaml
+++ b/kubernetes-operators/cluster-role.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: mysql-admin
+rules:
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["create", "patch", "update", "delete"]
+  - apiGroups: ["otus.homework"]
+    resources: ["mysqls"]
+    verbs: ["*"]
+  - apiGroups: [""]
+    resources: ["services", "persistentvolumes", "persistentvolumeclaims"]
+    verbs: ["create", "patch", "update", "delete"]

--- a/kubernetes-operators/crd.yaml
+++ b/kubernetes-operators/crd.yaml
@@ -1,0 +1,30 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: mysqls.otus.homework
+spec:
+  scope: Namespaced
+  group: otus.homework
+  names:
+    plural: mysqls
+    singular: mysql
+    kind: MySQL
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                image:
+                  type: string
+                database:
+                  type: string
+                password:
+                  type: string
+                storage_size:
+                  type: string

--- a/kubernetes-operators/deployment.yaml
+++ b/kubernetes-operators/deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: operators
+  labels:
+    app: operators
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: operators
+  template:
+    metadata:
+      labels:
+        app: operators
+    spec:
+      containers:
+      - name: mysql
+        image: roflmaoinmysoul/mysql-operator:1.0.0
+      serviceAccountName: mysql-admin

--- a/kubernetes-operators/mysql.yaml
+++ b/kubernetes-operators/mysql.yaml
@@ -1,0 +1,9 @@
+apiVersion: "otus.homework/v1"
+kind: MySQL
+metadata:
+  name: mysql
+spec:
+  image: mysql
+  database: operatorbase
+  password: passw0rd
+  storage_size: 1Gi

--- a/kubernetes-operators/service-account.yaml
+++ b/kubernetes-operators/service-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mysql-admin


### PR DESCRIPTION
**Задание**

- Создать манифест объекта CustomResourceDefinition со следующими параметрами:
- Объект уровня namespace
- Api group – otus.homework
- Kind – MySQL
- Plural name – mysqls
- Версия – v1
- Объект должен иметь следующие обязательные атрибуты и правила их валидации(все поля строковые):
- Image – определяет docker-образ для создания
- Database – имя базы данных
- Password – пароль от БД
- Storage_size – размер хранилища под базу 
- Создать манифесты ServiceAccount, ClusterRole и ClusterRoleBinding, описывающий сервис аккаунт с полными правами на доступ к api серверу
- Создать манифест deployment для оператора, указав созданный ранее ServiceAccount и образ roflmaoinmysoul/mysql-operator:1.0.0
- Создать манифест кастомного объекта kind: MySQL валидный для применения (см. атрибуты CRD созданного ранее)
- Применить все манифесты и убедиться, что CRD создался, оператор работает и при создании кастомного ресурса типа MySQL создает Deployment с указанным образом mysql, service для него, PV и PVC. При удалении объекта типа MySQL удаляются все созданные для него ресурсы

**Задание** со *

Изменить манифест ClusterRole, описав в нем минимальный набор прав доступа необходимые для нашего CRD и убедиться что функциональность не пострадала
- Управление сами ресурсом CRD
- Создание и удаление ресурсов типа Service, PV, PVC

**Задание****

Создать свой оператор, который будет реализовывать следующий функционал:
- При создании в кластере объектов с типом MySQL (mysqls.otus.homework/v1) будет создавать deployment с заданным образом mysql, сервис типа ClusterIP, PV и PVC заданного размера
- При удалении объекта с типом MySQL будет удалять ранее созданные ресурсы

**Запуск задания:**
```
kubectl apply -f cluster-role.yaml -f service-account.yaml -f cluster-role-binding.yaml
kubectl apply -f crd.yaml
kubectl apply -f deployment.yaml -f mysql.yaml
```

**Проверка работоспособности:**
1.Наличие объектов
`kubectl get svc,deploymet,pods,mysqls,sa,crd,pvc,pv`

2.Проверка mysql
```
kubectl port-forward *** 3306:3306
telnet 127.0.0.1 3306
mysql -h 127.0.0.1 -P 3306 -u root -p operatorbase
```